### PR TITLE
improve query performance and commit performance in some cases

### DIFF
--- a/src/Crdt.Core/CommitBase.cs
+++ b/src/Crdt.Core/CommitBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Hashing;
 using System.Text.Json.Serialization;
 
@@ -12,37 +13,23 @@ public abstract class CommitBase
 {
     public const string NullParentHash = "0000";
     [JsonConstructor]
-    protected internal CommitBase(Guid id, string hash, string parentHash, HybridDateTime hybridDateTime)
+    protected internal CommitBase(Guid id, HybridDateTime hybridDateTime)
     {
         Id = id;
-        Hash = hash;
-        ParentHash = parentHash;
         HybridDateTime = hybridDateTime;
     }
 
     internal CommitBase(Guid id)
     {
         Id = id;
-        Hash = GenerateHash(NullParentHash);
-        ParentHash = NullParentHash;
     }
 
     public (DateTimeOffset, long, Guid) CompareKey => (HybridDateTime.DateTime, HybridDateTime.Counter, Id);
     public Guid Id { get; }
     public required HybridDateTime HybridDateTime { get; init; }
     public DateTimeOffset DateTime => HybridDateTime.DateTime;
-    [JsonIgnore]
-    public string Hash { get; private set; }
-
-    [JsonIgnore]
-    public string ParentHash { get; private set; }
     public CommitMetadata Metadata { get; init; } = new();
 
-    public void SetParentHash(string parentHash)
-    {
-        Hash = GenerateHash(parentHash);
-        ParentHash = parentHash;
-    }
 
     public string GenerateHash(string parentHash)
     {
@@ -65,7 +52,7 @@ public abstract class CommitBase
 /// <inheritdoc cref="CommitBase"/>
 public abstract class CommitBase<TChange> : CommitBase
 {
-    internal CommitBase(Guid id, string hash, string parentHash, HybridDateTime hybridDateTime) : base(id, hash, parentHash, hybridDateTime)
+    internal CommitBase(Guid id, HybridDateTime hybridDateTime) : base(id, hybridDateTime)
     {
     }
 

--- a/src/Crdt.Core/QueryHelpers.cs
+++ b/src/Crdt.Core/QueryHelpers.cs
@@ -32,9 +32,11 @@ public static class QueryHelpers
                 var otherDt = DateTimeOffset.FromUnixTimeMilliseconds(otherTimestamp);
                 //todo even slower we want to also filter out changes that are already in the other history
                 //client has newer history than the other history
-                newHistory.AddRange(await commits.Include(c => c.ChangeEntities).DefaultOrder()
+                newHistory.AddRange((await commits.Include(c => c.ChangeEntities).DefaultOrder()
                     .Where(c => c.ClientId == clientId && c.HybridDateTime.DateTime > otherDt)
-                    .ToArrayAsync());
+                    .ToArrayAsync())
+                    //fixes an issue where the query would include commits that are already in the other history
+                    .Where(c => c.DateTime.ToUnixTimeMilliseconds() > otherTimestamp));
             }
         }
 

--- a/src/Crdt.Core/ServerCommit.cs
+++ b/src/Crdt.Core/ServerCommit.cs
@@ -7,9 +7,7 @@ namespace Crdt.Core;
 public class ServerCommit : CommitBase<ServerJsonChange>
 {
     [JsonConstructor]
-    protected ServerCommit(Guid id, string hash, string parentHash, HybridDateTime hybridDateTime) : base(id,
-        hash,
-        parentHash,
+    protected ServerCommit(Guid id, HybridDateTime hybridDateTime) : base(id,
         hybridDateTime)
     {
     }

--- a/src/Crdt.Tests/DataModelSimpleChanges.WriteMultipleCommits.verified.txt
+++ b/src/Crdt.Tests/DataModelSimpleChanges.WriteMultipleCommits.verified.txt
@@ -17,6 +17,8 @@
         IsRoot: true
       }
     ],
+    Hash: Hash_1,
+    ParentHash: Hash_Empty,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -41,8 +43,6 @@
       DateTime: DateTimeOffset_1
     },
     DateTime: DateTimeOffset_1,
-    Hash: Hash_1,
-    ParentHash: Hash_Empty,
     Metadata: {
       $type: CommitMetadata
     },
@@ -66,6 +66,8 @@
         IsRoot: true
       }
     ],
+    Hash: Hash_2,
+    ParentHash: Hash_1,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -90,8 +92,6 @@
       DateTime: DateTimeOffset_2
     },
     DateTime: DateTimeOffset_2,
-    Hash: Hash_2,
-    ParentHash: Hash_1,
     Metadata: {
       $type: CommitMetadata
     },

--- a/src/Crdt.Tests/DataModelSimpleChanges.Writing2ChangesAtOnceWithMergedHistory.verified.txt
+++ b/src/Crdt.Tests/DataModelSimpleChanges.Writing2ChangesAtOnceWithMergedHistory.verified.txt
@@ -17,6 +17,8 @@
         IsRoot: true
       }
     ],
+    Hash: Hash_1,
+    ParentHash: Hash_Empty,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -41,8 +43,6 @@
       DateTime: DateTimeOffset_1
     },
     DateTime: DateTimeOffset_1,
-    Hash: Hash_1,
-    ParentHash: Hash_Empty,
     Metadata: {
       $type: CommitMetadata
     },
@@ -67,6 +67,8 @@
         IsRoot: false
       }
     ],
+    Hash: Hash_2,
+    ParentHash: Hash_1,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -91,8 +93,6 @@
       DateTime: DateTimeOffset_2
     },
     DateTime: DateTimeOffset_2,
-    Hash: Hash_2,
-    ParentHash: Hash_1,
     Metadata: {
       $type: CommitMetadata
     },
@@ -116,6 +116,8 @@
         IsRoot: false
       }
     ],
+    Hash: Hash_3,
+    ParentHash: Hash_2,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -140,8 +142,6 @@
       DateTime: DateTimeOffset_3
     },
     DateTime: DateTimeOffset_3,
-    Hash: Hash_3,
-    ParentHash: Hash_2,
     Metadata: {
       $type: CommitMetadata
     },
@@ -166,6 +166,8 @@
         IsRoot: false
       }
     ],
+    Hash: Hash_4,
+    ParentHash: Hash_3,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -190,8 +192,6 @@
       DateTime: DateTimeOffset_4
     },
     DateTime: DateTimeOffset_4,
-    Hash: Hash_4,
-    ParentHash: Hash_3,
     Metadata: {
       $type: CommitMetadata
     },

--- a/src/Crdt.Tests/DataModelSimpleChanges.WritingA2ndChangeDoesNotEffectTheFirstSnapshot.verified.txt
+++ b/src/Crdt.Tests/DataModelSimpleChanges.WritingA2ndChangeDoesNotEffectTheFirstSnapshot.verified.txt
@@ -17,6 +17,8 @@
         IsRoot: true
       }
     ],
+    Hash: Hash_1,
+    ParentHash: Hash_Empty,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -41,8 +43,6 @@
       DateTime: DateTimeOffset_1
     },
     DateTime: DateTimeOffset_1,
-    Hash: Hash_1,
-    ParentHash: Hash_Empty,
     Metadata: {
       $type: CommitMetadata
     },
@@ -66,6 +66,8 @@
         IsRoot: false
       }
     ],
+    Hash: Hash_2,
+    ParentHash: Hash_1,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -90,8 +92,6 @@
       DateTime: DateTimeOffset_2
     },
     DateTime: DateTimeOffset_2,
-    Hash: Hash_2,
-    ParentHash: Hash_1,
     Metadata: {
       $type: CommitMetadata
     },

--- a/src/Crdt.Tests/DataModelSimpleChanges.WritingAChangeMakesASnapshot.verified.txt
+++ b/src/Crdt.Tests/DataModelSimpleChanges.WritingAChangeMakesASnapshot.verified.txt
@@ -17,6 +17,8 @@
         IsRoot: true
       }
     ],
+    Hash: Hash_1,
+    ParentHash: Hash_Empty,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -41,8 +43,6 @@
       DateTime: DateTimeOffset_1
     },
     DateTime: DateTimeOffset_1,
-    Hash: Hash_1,
-    ParentHash: Hash_Empty,
     Metadata: {
       $type: CommitMetadata
     },

--- a/src/Crdt.Tests/DataModelSimpleChanges.WritingACommitWithMultipleChangesWorks.verified.txt
+++ b/src/Crdt.Tests/DataModelSimpleChanges.WritingACommitWithMultipleChangesWorks.verified.txt
@@ -31,6 +31,8 @@
         IsRoot: true
       }
     ],
+    Hash: Hash_1,
+    ParentHash: Hash_Empty,
     ChangeEntities: [
       {
         $type: ChangeEntity<IChange>,
@@ -67,8 +69,6 @@
       DateTime: DateTimeOffset_1
     },
     DateTime: DateTimeOffset_1,
-    Hash: Hash_1,
-    ParentHash: Hash_Empty,
     Metadata: {
       $type: CommitMetadata
     },

--- a/src/Crdt/Commit.cs
+++ b/src/Crdt/Commit.cs
@@ -9,16 +9,23 @@ public class Commit : CommitBase<IChange>
 {
     [JsonConstructor]
     protected Commit(Guid id, string hash, string parentHash, HybridDateTime hybridDateTime) : base(id,
-        hash,
-        parentHash,
         hybridDateTime)
     {
+        Hash = hash;
+        ParentHash = parentHash;
     }
 
     internal Commit(Guid id) : base(id)
     {
+        Hash = GenerateHash(NullParentHash);
+        ParentHash = NullParentHash;
     }
 
+    public void SetParentHash(string parentHash)
+    {
+        Hash = GenerateHash(parentHash);
+        ParentHash = parentHash;
+    }
     internal Commit() : this(Guid.NewGuid())
     {
 
@@ -26,4 +33,10 @@ public class Commit : CommitBase<IChange>
 
     [JsonIgnore]
     public List<ObjectSnapshot> Snapshots { get; init; } = [];
+
+    [JsonIgnore]
+    public string Hash { get; private set; }
+
+    [JsonIgnore]
+    public string ParentHash { get; private set; }
 }

--- a/src/Crdt/CrdtConfig.cs
+++ b/src/Crdt/CrdtConfig.cs
@@ -9,7 +9,11 @@ namespace Crdt;
 
 public class CrdtConfig
 {
-    public bool EnableProjectedTables { get; set; } = false;
+    /// <summary>
+    /// recommended to increase query performance, as getting objects can just query the table for that object.
+    /// it does however increase database size as now objects are stored both in snapshots and in their projected tables
+    /// </summary>
+    public bool EnableProjectedTables { get; set; } = true;
     public ChangeTypeListBuilder ChangeTypeListBuilder { get; } = new();
     public ObjectTypeListBuilder ObjectTypeListBuilder { get; } = new();
 

--- a/src/Crdt/DataModel.cs
+++ b/src/Crdt/DataModel.cs
@@ -9,7 +9,7 @@ namespace Crdt;
 
 public record SyncResults(Commit[] MissingFromLocal, Commit[] MissingFromRemote, bool IsSynced);
 
-public class DataModel : ISyncable
+public class DataModel : ISyncable, IAsyncDisposable
 {
     /// <summary>
     /// after adding any commit validate the commit history, not great for performance but good for testing.
@@ -61,7 +61,8 @@ public class DataModel : ISyncable
         Guid clientId,
         IEnumerable<IChange> changes,
         Guid commitId = default,
-        CommitMetadata? commitMetadata = null)
+        CommitMetadata? commitMetadata = null,
+        bool deferCommit = false)
     {
         commitId = commitId == default ? Guid.NewGuid() : commitId;
         var commit = new Commit(commitId)
@@ -71,19 +72,37 @@ public class DataModel : ISyncable
             ChangeEntities = [..changes.Select(ToChangeEntity)],
             Metadata = commitMetadata ?? new()
         };
-        await Add(commit);
+        await Add(commit, deferCommit);
         return commit;
-    }
+    } 
 
-    private async Task Add(Commit commit)
+    private readonly List<Commit> _deferredCommits = [];
+    private async Task Add(Commit commit, bool deferSnapshotUpdates)
     {
         if (await _crdtRepository.HasCommit(commit.Id)) return;
 
         await using var transaction = await _crdtRepository.BeginTransactionAsync();
         await _crdtRepository.AddCommit(commit);
-        await UpdateSnapshots(commit, [commit]);
-        if (_autoValidate) await ValidateCommits();
+        if (!deferSnapshotUpdates)
+        {
+            await UpdateSnapshots(commit, [commit]);
+            if (_autoValidate) await ValidateCommits();
+        }
+        else
+        {
+            _deferredCommits.Add(commit);
+        }
         await transaction.CommitAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_deferredCommits is []) return;
+        var commits = _deferredCommits.ToArray();
+        var oldestChange = commits.MinBy(c => c.CompareKey);
+        if (oldestChange is null) return;
+        await UpdateSnapshots(oldestChange, commits);
+        if (_autoValidate) await ValidateCommits();
     }
 
     private static ChangeEntity<IChange> ToChangeEntity(IChange change, int index)

--- a/src/Crdt/Db/CrdtRepository.cs
+++ b/src/Crdt/Db/CrdtRepository.cs
@@ -137,15 +137,14 @@ internal class CrdtRepository(CrdtDbContext _dbContext, IOptions<CrdtConfig> crd
         return snapshot?.Entity.Is<T>();
     }
 
-    public IQueryable<T> GetCurrentObjects<T>(Expression<Func<ObjectSnapshot, bool>>? predicate = null) where T : class, IObjectBase
+    public IQueryable<T> GetCurrentObjects<T>() where T : class, IObjectBase
     {
-        if (crdtConfig.Value.EnableProjectedTables && predicate is null)
+        if (crdtConfig.Value.EnableProjectedTables)
         {
-            return _dbContext.Set<T>().Where(e => CurrentSnapshotIds().Contains(EF.Property<Guid>(e, ObjectSnapshot.ShadowRefName)));
+            return _dbContext.Set<T>();
         }
         var typeName = DerivedTypeHelper.GetEntityDiscriminator<T>();
         var queryable = CurrentSnapshots().Where(s => s.TypeName == typeName && !s.EntityIsDeleted);
-        if (predicate is not null) queryable = queryable.Where(predicate);
         return queryable.Select(s => (T)s.Entity);
     }
 


### PR DESCRIPTION
previously `GetCurrentObjects` would always filter on latest snapshots as a safety measure, however this is really bad for performance with a large database, and it's not nessecary considering the projected table is always the latest state. Removing the filter increases performance by an order of magnitude when a large number of commits is involved.

I also added the ability to defer updating snapshots, this can be used when intending to add multiple commits at a time (for example importing a project), the snapshots will be updated once the DataModel is disposed of by the IoC container. Though it might be a good idea to expose a method to explicitly update those defered updates